### PR TITLE
Create Github User Search UI

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,10 +1,12 @@
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.jsx"
+  stories: [
+    '../src/**/*.stories.jsx'
   ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-actions',
+    '@storybook/addon-controls',
     'storybook-addon-apollo-client'
   ]
-}
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
+import { StylesProvider } from '@material-ui/core/styles';
 import { addDecorator, addParameters } from '@storybook/react';
 import {
   INITIAL_VIEWPORTS,
@@ -18,10 +19,12 @@ addParameters({
 });
 
 addDecorator(Story => (
-  <ThemeProvider theme={darkTheme}>
-    <GlobalStyle />
-    <Story />
-  </ThemeProvider>
+  <StylesProvider>
+    <ThemeProvider theme={darkTheme}>
+      <GlobalStyle />
+      <Story />
+    </ThemeProvider>
+  </StylesProvider>
 ));
 
 export const parameters = {};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "graphql-tag": "^2.11.0",
     "isomorphic-unfetch": "^3.1.0",
     "next": "10.0.3",
+    "polished": "^4.0.5",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-helmet": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-env": "^7.12.10",
     "@babel/preset-react": "^7.12.10",
     "@storybook/addon-actions": "^6.1.11",
+    "@storybook/addon-controls": "^6.1.11",
     "@storybook/addon-essentials": "^6.1.11",
     "@storybook/addon-links": "^6.1.11",
     "@storybook/addon-viewport": "^6.1.11",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-helmet": "^6.1.0",
+    "react-hook-form": "^6.13.0",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@apollo/react-hooks": "^4.0.0",
     "@apollo/react-ssr": "^4.0.0",
     "@babel/runtime": "^7.12.5",
+    "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link-http": "^1.5.17",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "yarn test:lint",
+    "lint": "eslint",
     "test": "run-p test:*",
     "test:unit": "jest --coverage",
     "test:browser": "run-s test:browser:*",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { ApolloProvider } from '@apollo/react-hooks';
 import { ThemeProvider } from 'styled-components';
-import { StylesProvider } from '@material-ui/core/styles';
 
 import useApollo from 'shared/apollo';
 import GlobalStyle from 'shared/global-style';
@@ -11,33 +10,31 @@ import { darkTheme } from 'components/styles/theme';
 const defaultTitle = 'Next Playground';
 
 export const AppWrapper = ({ children }) => (
-  <StylesProvider>
-    <ThemeProvider theme={darkTheme}>
-      <GlobalStyle />
-      <Helmet
-        htmlAttributes={{ lang: 'en' }}
-        title={defaultTitle}
-        link={[
-          {
-            rel: 'icon',
-            href: '/favicon.ico',
-          },
-        ]}
-        meta={[
-          {
-            name: 'viewport',
-            content: 'width=device-width, initial-scale=1',
-          },
-          { property: 'og:title', content: defaultTitle },
-          {
-            name: 'description',
-            content: 'A place to experiment with Next.js features.',
-          },
-        ]}
-      />
-      {children}
-    </ThemeProvider>
-  </StylesProvider>
+  <ThemeProvider theme={darkTheme}>
+    <GlobalStyle />
+    <Helmet
+      htmlAttributes={{ lang: 'en' }}
+      title={defaultTitle}
+      link={[
+        {
+          rel: 'icon',
+          href: '/favicon.ico',
+        },
+      ]}
+      meta={[
+        {
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1',
+        },
+        { property: 'og:title', content: defaultTitle },
+        {
+          name: 'description',
+          content: 'A place to experiment with Next.js features.',
+        },
+      ]}
+    />
+    {children}
+  </ThemeProvider>
 );
 
 const App = ({ Component, pageProps }) => {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { ApolloProvider } from '@apollo/react-hooks';
 import { ThemeProvider } from 'styled-components';
+import { StylesProvider } from '@material-ui/core/styles';
 
 import useApollo from 'shared/apollo';
 import GlobalStyle from 'shared/global-style';
@@ -10,31 +11,33 @@ import { darkTheme } from 'components/styles/theme';
 const defaultTitle = 'Next Playground';
 
 export const AppWrapper = ({ children }) => (
-  <ThemeProvider theme={darkTheme}>
-    <GlobalStyle />
-    <Helmet
-      htmlAttributes={{ lang: 'en' }}
-      title={defaultTitle}
-      link={[
-        {
-          rel: 'icon',
-          href: '/favicon.ico',
-        },
-      ]}
-      meta={[
-        {
-          name: 'viewport',
-          content: 'width=device-width, initial-scale=1',
-        },
-        { property: 'og:title', content: defaultTitle },
-        {
-          name: 'description',
-          content: 'A place to experiment with Next.js features.',
-        },
-      ]}
-    />
-    {children}
-  </ThemeProvider>
+  <StylesProvider>
+    <ThemeProvider theme={darkTheme}>
+      <GlobalStyle />
+      <Helmet
+        htmlAttributes={{ lang: 'en' }}
+        title={defaultTitle}
+        link={[
+          {
+            rel: 'icon',
+            href: '/favicon.ico',
+          },
+        ]}
+        meta={[
+          {
+            name: 'viewport',
+            content: 'width=device-width, initial-scale=1',
+          },
+          { property: 'og:title', content: defaultTitle },
+          {
+            name: 'description',
+            content: 'A place to experiment with Next.js features.',
+          },
+        ]}
+      />
+      {children}
+    </ThemeProvider>
+  </StylesProvider>
 );
 
 const App = ({ Component, pageProps }) => {

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import HelloWorld from 'components/atoms/hello-world';
+import UserSearch from 'components/organisms/user-search';
 
 const Home = () => (
   <>
     <Helmet
-      title="Hello there"
-      meta={[{ property: 'og:title', content: 'Hello there' }]}
+      title="Github User Search"
+      meta={[{ property: 'og:title', content: 'Github User Search' }]}
     />
 
-    <HelloWorld />
+    <UserSearch />
   </>
 );
 

--- a/src/components/atoms/avatar/avatar.jsx
+++ b/src/components/atoms/avatar/avatar.jsx
@@ -1,0 +1,3 @@
+import UIAvatar from '@material-ui/core/Avatar';
+
+export default UIAvatar;

--- a/src/components/atoms/avatar/index.jsx
+++ b/src/components/atoms/avatar/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './avatar';

--- a/src/components/atoms/button/button.client.test.jsx
+++ b/src/components/atoms/button/button.client.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, fireEvent } from 'unit-test-utils';
+import Button from '.';
+
+test('button handles clicks', () => {
+  const onClick = jest.fn();
+  const { getByText } = render(<Button onClick={onClick}>Test Button</Button>);
+
+  fireEvent.click(getByText('Test Button'));
+  expect(onClick).toHaveBeenCalled();
+});

--- a/src/components/atoms/button/button.jsx
+++ b/src/components/atoms/button/button.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import StyledButton from './button.styles';
+
+const Button = ({
+  children,
+  onClick,
+  color = 'default',
+  disabled = false,
+  fullWidth = false,
+  size = 'medium',
+  variant = 'contained',
+  buttonType = 'button',
+}) => (
+  <StyledButton
+    color={color}
+    disabled={disabled}
+    fullWidth={fullWidth}
+    size={size}
+    variant={variant}
+    onClick={onClick}
+    type={buttonType}
+  >
+    {children}
+  </StyledButton>
+);
+
+export default Button;

--- a/src/components/atoms/button/button.stories.jsx
+++ b/src/components/atoms/button/button.stories.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import Button from './index';
+
+export default {
+  title: 'Atoms/Button',
+  component: Button,
+  argTypes: {
+    onClick: { action: 'clicked' },
+    color: {
+      control: {
+        type: 'select',
+        options: ['default', 'primary', 'secondary'],
+      },
+    },
+    disabled: {
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    fullWidth:{
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large'],
+      },
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: ['contained', 'outlined', 'text'],
+      },
+    },
+    buttonType: {
+      control: {
+        type: 'select',
+        options: ['button', 'submit'],
+      },
+    },
+  },
+};
+
+const Template = (args) => <Button {...args}>My Button</Button>;
+
+export const StandardButton = Template.bind({});
+StandardButton.args = {
+  color: 'default',
+  disabled: false,
+  fullWidth: false,
+  size: 'medium',
+  variant: 'contained',
+  buttonType: 'button',
+};

--- a/src/components/atoms/button/button.styles.js
+++ b/src/components/atoms/button/button.styles.js
@@ -1,0 +1,6 @@
+import UIButton from '@material-ui/core/Button';
+import styled from 'styled-components';
+
+const StyledButton = styled(UIButton)``;
+
+export default StyledButton;

--- a/src/components/atoms/button/index.jsx
+++ b/src/components/atoms/button/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './button';

--- a/src/components/atoms/error/error.jsx
+++ b/src/components/atoms/error/error.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Error = ({ error }) => <p>{error.message}</p>;
+
+export default Error;

--- a/src/components/atoms/error/index.jsx
+++ b/src/components/atoms/error/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './error';

--- a/src/components/atoms/loading/index.jsx
+++ b/src/components/atoms/loading/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './loading';

--- a/src/components/atoms/loading/loading.jsx
+++ b/src/components/atoms/loading/loading.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Loading = () => <p>loading...</p>;
+
+export default Loading;

--- a/src/components/atoms/text-input/index.jsx
+++ b/src/components/atoms/text-input/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './text-input';

--- a/src/components/atoms/text-input/text-input.client.test.jsx
+++ b/src/components/atoms/text-input/text-input.client.test.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from 'unit-test-utils';
+import TextInput from '.';
+
+test('render usable input text field', () => {
+  const { getByTestId } = render(<TextInput id="test-id" />);
+  expect(getByTestId('test-id-text-input')).toBeInTheDocument();
+});

--- a/src/components/atoms/text-input/text-input.jsx
+++ b/src/components/atoms/text-input/text-input.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import StyledInput from './text-input.styles';
+
+const TextInput = React.forwardRef(
+  (
+    {
+      id,
+      name,
+      onChange,
+      label,
+      autoComplete = 'true',
+      autoFocus = false,
+      defaultValue = null,
+      disabled = false,
+      fullWidth = false,
+      placeholder = '',
+      required = false,
+      type = 'text',
+    },
+    ref,
+  ) => (
+    <StyledInput
+      id={id}
+      name={name}
+      onChange={onChange}
+      label={label}
+      autoComplete={autoComplete}
+      autoFocus={autoFocus}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      fullWidth={fullWidth}
+      placeholder={placeholder}
+      required={required}
+      type={type}
+      inputRef={ref}
+      data-testid={`${id}-text-input`}
+    />
+  )
+);
+
+export default TextInput;

--- a/src/components/atoms/text-input/text-input.jsx
+++ b/src/components/atoms/text-input/text-input.jsx
@@ -16,6 +16,7 @@ const TextInput = React.forwardRef(
       placeholder = '',
       required = false,
       type = 'text',
+      variant = 'standard',
     },
     ref,
   ) => (
@@ -32,6 +33,7 @@ const TextInput = React.forwardRef(
       placeholder={placeholder}
       required={required}
       type={type}
+      variant={variant}
       inputRef={ref}
       data-testid={`${id}-text-input`}
     />

--- a/src/components/atoms/text-input/text-input.stories.jsx
+++ b/src/components/atoms/text-input/text-input.stories.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import TextInput from './index';
+
+export default {
+  title: 'Atoms/TextInput',
+  component: TextInput,
+  argTypes: {
+    onClick: { action: 'clicked' },
+    autoComplete: {
+      control: {
+        type: 'text',
+      },
+    },
+    autoFocus: {
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    disabled: {
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    fullWidth:{
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    placeholder: {
+      control: {
+        type: 'text',
+      },
+    },
+    required:{
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    type:{
+      control: {
+        type: 'text',
+      },
+    },
+  },
+};
+
+const Template = (args) => <TextInput {...args} />;
+
+export const SimpleTextInput = Template.bind({});
+SimpleTextInput.args = {
+  id: 'test-input',
+  name: 'test',
+  label: 'Test Input Field',
+  autoFocus: true,
+  defaultValue: '',
+  dsiabled: false,
+  fullWidth: false,
+  placeholder: 'Placeholder text',
+  required: false,
+  type: 'text',
+};

--- a/src/components/atoms/text-input/text-input.stories.jsx
+++ b/src/components/atoms/text-input/text-input.stories.jsx
@@ -45,6 +45,12 @@ export default {
         type: 'text',
       },
     },
+    variant: {
+      control: {
+        type: 'select',
+        options: ['standard', 'filled', 'outlined'],
+      },
+    },
   },
 };
 

--- a/src/components/atoms/text-input/text-input.styles.js
+++ b/src/components/atoms/text-input/text-input.styles.js
@@ -1,0 +1,6 @@
+import TextField from '@material-ui/core/TextField';
+import styled from 'styled-components';
+
+const StyledInput = styled(TextField)``;
+
+export default StyledInput;

--- a/src/components/molecules/organization-result/index.jsx
+++ b/src/components/molecules/organization-result/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './organization-result';

--- a/src/components/molecules/organization-result/organization-result.jsx
+++ b/src/components/molecules/organization-result/organization-result.jsx
@@ -26,7 +26,7 @@ const OrganizationResult = ({
     </AvatarContainer>
     <DetailsContainer>
       <Row>
-        <NameDisplay>Organization: {name}</NameDisplay>
+        <NameDisplay>{name}</NameDisplay>
         <UsernameDisplay>{login}</UsernameDisplay>
       </Row>
       <Row>

--- a/src/components/molecules/organization-result/organization-result.jsx
+++ b/src/components/molecules/organization-result/organization-result.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Avatar from 'components/atoms/avatar';
+
+import {
+  OrganizationResultContainer,
+  AvatarContainer,
+  DetailsContainer,
+  StatsContainer,
+  Row,
+  NameDisplay,
+  UsernameDisplay,
+} from './organization-result.styles';
+
+const OrganizationResult = ({
+  avatarUrl,
+  description,
+  email,
+  location,
+  login,
+  name,
+  url,
+}) => (
+  <OrganizationResultContainer href={url} target="_blank">
+    <AvatarContainer>
+      <Avatar atl={login} src={avatarUrl} />
+    </AvatarContainer>
+    <DetailsContainer>
+      <Row>
+        <NameDisplay>Organization: {name}</NameDisplay>
+        <UsernameDisplay>{login}</UsernameDisplay>
+      </Row>
+      <Row>
+        <StatsContainer>{description}</StatsContainer>
+      </Row>
+      <Row>
+        <StatsContainer>{location || 'Location Unavailable'}</StatsContainer>
+        <StatsContainer>{email || 'Email Unavailable'}</StatsContainer>
+      </Row>
+    </DetailsContainer>
+  </OrganizationResultContainer>
+);
+
+export default OrganizationResult;

--- a/src/components/molecules/organization-result/organization-result.styles.js
+++ b/src/components/molecules/organization-result/organization-result.styles.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const OrganizationResultContainer = styled.a`
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: row;
+  padding: 1rem;
+  width: 100%;
+
+  &:hover {
+    background-color: #eee;
+  }
+`;
+
+export const AvatarContainer = styled.div`
+  margin-right: 0.25rem;
+`;
+
+export const DetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StatsContainer = styled.span`
+  margin-right: 1rem;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+export const NameDisplay = styled.span`
+  color: blue;
+  margin-right: 0.25rem;
+`;
+
+export const UsernameDisplay = styled.span`
+  color: gray;
+  font-weight: 900;
+`;

--- a/src/components/molecules/search-input/index.jsx
+++ b/src/components/molecules/search-input/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './search-input';

--- a/src/components/molecules/search-input/search-input.jsx
+++ b/src/components/molecules/search-input/search-input.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Button from 'components/atoms/button';
+import TextInput from 'components/atoms/text-input';
+
+const SearchInput = () => (
+  <>
+    <TextInput variant="outlined" />
+    <Button>Search</Button>
+  </>
+);
+
+export default SearchInput;

--- a/src/components/molecules/search-input/search-input.stories.jsx
+++ b/src/components/molecules/search-input/search-input.stories.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import SearchInput from './index';
+
+export default {
+  title: 'Molecules/SearchInput',
+  component: SearchInput,
+  argTypes: {
+    onClick: { action: 'clicked' },
+    autoComplete: {
+      control: {
+        type: 'text',
+      },
+    },
+    autoFocus: {
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    disabled: {
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    fullWidth:{
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    placeholder: {
+      control: {
+        type: 'text',
+      },
+    },
+    required:{
+      control: {
+        type: 'inline-radio',
+        options: [false, true],
+      },
+    },
+    type: {
+      control: {
+        type: 'text',
+      },
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: ['standard', 'filled', 'outlined'],
+      },
+    },
+  },
+};
+
+const Template = (args) => <SearchInput {...args} />;
+
+export const SimpleTextInput = Template.bind({});
+SimpleTextInput.args = {
+  id: 'test-input',
+  name: 'test',
+  label: 'Test Input Field',
+  autoFocus: true,
+  defaultValue: '',
+  dsiabled: false,
+  fullWidth: false,
+  placeholder: 'Placeholder text',
+  required: false,
+  type: 'text',
+  variant: 'standard',
+};

--- a/src/components/molecules/user-result/index.jsx
+++ b/src/components/molecules/user-result/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './user-result';

--- a/src/components/molecules/user-result/user-result.jsx
+++ b/src/components/molecules/user-result/user-result.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Avatar from 'components/atoms/avatar';
+
+import {
+  UserResultContainer,
+  AvatarContainer,
+  DetailsContainer,
+  StatsContainer,
+  Row,
+  NameDisplay,
+  UsernameDisplay,
+} from './user-result.styles';
+
+const UserResult = ({
+  avatarUrl,
+  email,
+  followersCount,
+  followingCount,
+  location,
+  login,
+  name,
+  starredRepositoriesCount,
+  url,
+}) => (
+  <UserResultContainer href={url} target="_blank">
+    <AvatarContainer>
+      <Avatar atl={login} src={avatarUrl} />
+    </AvatarContainer>
+    <DetailsContainer>
+      <Row>
+        <NameDisplay>{name}</NameDisplay>
+        <UsernameDisplay>{login}</UsernameDisplay>
+      </Row>
+      <Row>
+        <StatsContainer>Followers: {followersCount}</StatsContainer>
+        <StatsContainer>Following: {followingCount}</StatsContainer>
+        <StatsContainer>Starred: {starredRepositoriesCount}</StatsContainer>
+      </Row>
+      <Row>
+        <StatsContainer>{location || 'Location Unavailable'}</StatsContainer>
+        <StatsContainer>{email || 'Email Unavailable'}</StatsContainer>
+      </Row>
+    </DetailsContainer>
+  </UserResultContainer>
+);
+
+export default UserResult;

--- a/src/components/molecules/user-result/user-result.styles.js
+++ b/src/components/molecules/user-result/user-result.styles.js
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const UserResultContainer = styled.a`
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: row;
+  padding: 1rem;
+  width: 100%;
+
+  &:hover {
+    background-color: #eee;
+  }
+`;
+
+export const AvatarContainer = styled.div`
+  margin-right: 0.25rem;
+`;
+
+export const DetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const StatsContainer = styled.span`
+  margin-right: 1rem;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+export const NameDisplay = styled.span`
+  color: blue;
+  margin-right: 0.25rem;
+`;
+
+export const UsernameDisplay = styled.span`
+  color: gray;
+  font-weight: 900;
+`;

--- a/src/components/organisms/user-search/index.jsx
+++ b/src/components/organisms/user-search/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './user-search.controller';

--- a/src/components/organisms/user-search/user-search.controller.jsx
+++ b/src/components/organisms/user-search/user-search.controller.jsx
@@ -4,19 +4,13 @@ import USER_SEARCH_QUERY from 'gql/user-search-query';
 import UserSearch from './user-search.view';
 
 const UserSearchController = () => {
-  const [searchQuery, setSearchQuery] = useState('example');
-  const [cursor, setCusor] = useState({ next: null, prev: null });
+  const [searchQuery, setSearchQuery] = useState(null);
+  const [paginate, setPaginate] = useState({ first: 30 });
 
   const variables = {
     query: searchQuery,
-    first: 30,
+    ...paginate,
   };
-
-  if (cursor.next) {
-    variables.after = cursor.next;
-  } else if (cursor.prev) {
-    variables.before = cursor.prev;
-  }
 
   const { data, loading, error } = useQuery(USER_SEARCH_QUERY, {
     variables,
@@ -44,17 +38,17 @@ const UserSearchController = () => {
   const { hasPreviousPage, hasNextPage, startCursor, endCursor } = pageInfo;
   const gotoNextPage = () => {
     if (!hasNextPage) return;
-    setCusor({
-      next: endCursor,
-      prev: null,
+    setPaginate({
+      first: 30,
+      after: endCursor,
     });
   };
 
   const gotoPrevPage = () => {
     if (!hasPreviousPage) return;
-    setCusor({
-      next: null,
-      prev: startCursor,
+    setPaginate({
+      last: 30,
+      before: startCursor,
     });
   };
 
@@ -66,7 +60,10 @@ const UserSearchController = () => {
       gotoPrevPage={gotoPrevPage}
       hasNextPage={pageInfo.hasNextPage}
       gotoNextPage={gotoNextPage}
-      setSearchQuery={setSearchQuery}
+      setSearchQuery={(newQuery) => {
+        setPaginate({ first: 30 });
+        setSearchQuery(newQuery);
+      }}
       loading={loading}
       error={error}
     />

--- a/src/components/organisms/user-search/user-search.controller.jsx
+++ b/src/components/organisms/user-search/user-search.controller.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import USER_SEARCH_QUERY from 'gql/user-search-query';
+import UserSearch from './user-search.view';
+
+const UserSearchController = () => {
+  const [searchQuery, setSearchQuery] = useState('example');
+  const [cursor, setCusor] = useState({ next: null, prev: null });
+
+  const variables = {
+    query: searchQuery,
+    first: 30,
+  };
+
+  if (cursor.next) {
+    variables.after = cursor.next;
+  } else if (cursor.prev) {
+    variables.before = cursor.prev;
+  }
+
+  const { data, loading, error } = useQuery(USER_SEARCH_QUERY, {
+    variables,
+    skip: !searchQuery,
+    fetchPolicy: 'no-cache',
+  });
+
+  const { nodes, pageInfo = {}, userCount } = data?.search ?? {};
+  const remappedResults = nodes?.map((node) => {
+    // eslint-disable-next-line no-underscore-dangle
+    switch (node.__typename) {
+      case 'User':
+        return {
+          ...node,
+          followersCount: node?.followers?.totalCount,
+          followingCount: node?.following?.totalCount,
+          starredRepositoriesCount: node?.starredRepositories?.totalCount,
+        };
+      case 'Organization':
+      default:
+        return node;
+    }
+  });
+
+  const { hasPreviousPage, hasNextPage, startCursor, endCursor } = pageInfo;
+  const gotoNextPage = () => {
+    if (!hasNextPage) return;
+    setCusor({
+      next: endCursor,
+      prev: null,
+    });
+  };
+
+  const gotoPrevPage = () => {
+    if (!hasPreviousPage) return;
+    setCusor({
+      next: null,
+      prev: startCursor,
+    });
+  };
+
+  return (
+    <UserSearch
+      results={remappedResults}
+      totalCount={userCount}
+      hasPrevPage={pageInfo.hasPreviousPage}
+      gotoPrevPage={gotoPrevPage}
+      hasNextPage={pageInfo.hasNextPage}
+      gotoNextPage={gotoNextPage}
+      setSearchQuery={setSearchQuery}
+      loading={loading}
+      error={error}
+    />
+  );
+};
+
+export default UserSearchController;

--- a/src/components/organisms/user-search/user-search.styles.js
+++ b/src/components/organisms/user-search/user-search.styles.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const UserSearchContainer = styled.div`
+  padding: 1rem 2rem;
+`;
+
+export const FormContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+export const FormErrorContainer = styled.div`
+  color: red;
+`;

--- a/src/components/organisms/user-search/user-search.view.jsx
+++ b/src/components/organisms/user-search/user-search.view.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import UserResult from 'components/molecules/user-result';
+import OrganizationResult from 'components/molecules/organization-result';
+
+const Loading = () => <p>loading...</p>;
+const Error = ({ error }) => <p>{error.message}</p>;
+
+const UserSearch = ({
+  results,
+  totalCount,
+  hasPrevPage,
+  gotoPrevPage,
+  hasNextPage,
+  gotoNextPage,
+  setSearchQuery,
+  loading,
+  error,
+}) => {
+  if (loading) {
+    return <p>loading...</p>;
+  }
+  return (
+    <>
+      <input type="text" placeholder="search field" />
+      <h3>Results: {totalCount}</h3>
+      <button>prev page</button>
+      <button>next page</button>
+      {loading && <Loading />}
+      {error && <Error error={error} />}
+      {results.map((node) => {
+        // eslint-disable-next-line no-underscore-dangle
+        switch (node.__typename) {
+          case 'User':
+            return <UserResult key={node.login} {...node} />;
+          case 'Organization':
+            return <OrganizationResult key={node.login} {...node} />;
+          default:
+            console.warn('Cannot render this type of result');
+            return null;
+        }
+      })}
+    </>
+  );
+};
+
+export default UserSearch;

--- a/src/components/organisms/user-search/user-search.view.jsx
+++ b/src/components/organisms/user-search/user-search.view.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
+
+import Loading from 'components/atoms/loading';
+import Error from 'components/atoms/error';
 import UserResult from 'components/molecules/user-result';
 import OrganizationResult from 'components/molecules/organization-result';
 
-const Loading = () => <p>loading...</p>;
-const Error = ({ error }) => <p>{error.message}</p>;
+import {
+  UserSearchContainer,
+  FormContainer,
+  FormErrorContainer,
+} from './user-search.styles';
 
 const UserSearch = ({
   results,
@@ -16,30 +23,57 @@ const UserSearch = ({
   loading,
   error,
 }) => {
-  if (loading) {
-    return <p>loading...</p>;
-  }
+  const { register, handleSubmit, errors } = useForm();
+  const onSubmit = ({ searchUsers }) => setSearchQuery(searchUsers);
+
   return (
-    <>
-      <input type="text" placeholder="search field" />
+    <UserSearchContainer>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <FormContainer>
+          <input
+            type="text"
+            placeholder="search field"
+            name="searchUsers"
+            defaultValue={null}
+            ref={register({ required: true })}
+          />
+
+          <input type="submit" />
+        </FormContainer>
+
+        {errors.searchUsers && (
+          <FormErrorContainer>Must provide a search string</FormErrorContainer>
+        )}
+      </form>
+
       <h3>Results: {totalCount}</h3>
-      <button>prev page</button>
-      <button>next page</button>
+      {hasPrevPage && (
+        <button type="button" onClick={gotoPrevPage}>
+          Previous
+        </button>
+      )}
+      {hasNextPage && (
+        <button type="button" onClick={gotoNextPage}>
+          Next
+        </button>
+      )}
       {loading && <Loading />}
       {error && <Error error={error} />}
-      {results.map((node) => {
-        // eslint-disable-next-line no-underscore-dangle
-        switch (node.__typename) {
-          case 'User':
-            return <UserResult key={node.login} {...node} />;
-          case 'Organization':
-            return <OrganizationResult key={node.login} {...node} />;
-          default:
-            console.warn('Cannot render this type of result');
-            return null;
-        }
-      })}
-    </>
+      {!loading &&
+        !error &&
+        results?.map((node) => {
+          // eslint-disable-next-line no-underscore-dangle
+          switch (node.__typename) {
+            case 'User':
+              return <UserResult key={node.login} {...node} />;
+            case 'Organization':
+              return <OrganizationResult key={node.login} {...node} />;
+            default:
+              console.warn('Cannot render this type of result');
+              return null;
+          }
+        })}
+    </UserSearchContainer>
   );
 };
 

--- a/src/components/styles/colors.js
+++ b/src/components/styles/colors.js
@@ -1,0 +1,10 @@
+const ColorPallete = {
+  black: 'rgb(18, 18, 18)',
+  darkGray: 'rgb(31, 31, 31)',
+  gray: 'rgb(33, 37, 44)',
+  white: 'rgb(201, 209, 217)',
+  blue: 'rgb(137, 171, 206)',
+  blueGray: 'rgb(185, 190, 198)',
+};
+
+export default ColorPallete;

--- a/src/components/styles/spacing.js
+++ b/src/components/styles/spacing.js
@@ -14,5 +14,6 @@ const proportionalSpacing = (proportion) =>
 
 const BASE_SPACING = proportionalSpacing(1);
 const DOUBLE_BASE_SPACING = proportionalSpacing(2);
+const HALF_BASE_SPACING = proportionalSpacing(0.5);
 
-export { BASE_SPACING, DOUBLE_BASE_SPACING, pixelToRem };
+export { BASE_SPACING, DOUBLE_BASE_SPACING, HALF_BASE_SPACING, pixelToRem };

--- a/src/components/styles/theme.client.test.js
+++ b/src/components/styles/theme.client.test.js
@@ -1,19 +1,23 @@
 import { lightTheme, darkTheme } from './theme';
 
 test('defines a lightTheme', () => {
-  expect(lightTheme).toEqual({
-    spacing: {
-      BASE_SPACING: '1rem',
-      DOUBLE_BASE_SPACING: '2rem',
-    },
-  });
+  expect(lightTheme).toEqual(
+    expect.objectContaining({
+      spacing: {
+        BASE_SPACING: '1rem',
+        DOUBLE_BASE_SPACING: '2rem',
+      },
+    }),
+  );
 });
 
 test('defines a darkTheme', () => {
-  expect(darkTheme).toEqual({
-    spacing: {
-      BASE_SPACING: '1rem',
-      DOUBLE_BASE_SPACING: '2rem',
-    },
-  });
+  expect(darkTheme).toEqual(
+    expect.objectContaining({
+      spacing: {
+        BASE_SPACING: '1rem',
+        DOUBLE_BASE_SPACING: '2rem',
+      },
+    }),
+  );
 });

--- a/src/components/styles/theme.js
+++ b/src/components/styles/theme.js
@@ -1,4 +1,6 @@
+import { darken } from 'polished';
 import { BASE_SPACING, DOUBLE_BASE_SPACING } from './spacing';
+import ColorPallete from './colors';
 
 export const lightTheme = {
   spacing: {
@@ -11,5 +13,23 @@ export const darkTheme = {
   spacing: {
     BASE_SPACING,
     DOUBLE_BASE_SPACING,
+  },
+  palette: {
+    background: {
+      primary: ColorPallete.black,
+      secondary: ColorPallete.darkGray,
+    },
+    text: {
+      primary: ColorPallete.white,
+      link: ColorPallete.blue,
+    },
+    input: {
+      text: ColorPallete.blueGray,
+    },
+    info: {
+      background: ColorPallete.gray,
+      text: ColorPallete.white,
+      active: darken('0.1', ColorPallete.gray),
+    },
   },
 };

--- a/src/gql/user-search-query.js
+++ b/src/gql/user-search-query.js
@@ -1,0 +1,45 @@
+import gql from 'graphql-tag';
+
+const USER_SEARCH_QUERY = gql`
+  query UserSearchQuery($query: String!, $first: Int!) {
+    search(query: $query, type: USER, first: $first) {
+      userCount
+      nodes {
+        ... on Organization {
+          avatarUrl
+          description
+          email
+          location
+          login
+          name
+          url
+        }
+        ... on User {
+          avatarUrl
+          email
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          location
+          login
+          name
+          starredRepositories {
+            totalCount
+          }
+          url
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+    }
+  }
+`;
+
+export default USER_SEARCH_QUERY;

--- a/src/gql/user-search-query.js
+++ b/src/gql/user-search-query.js
@@ -1,8 +1,21 @@
 import gql from 'graphql-tag';
 
 const USER_SEARCH_QUERY = gql`
-  query UserSearchQuery($query: String!, $first: Int!) {
-    search(query: $query, type: USER, first: $first) {
+  query UserSearchQuery(
+    $query: String!
+    $first: Int
+    $last: Int
+    $before: String
+    $after: String
+  ) {
+    search(
+      query: $query
+      type: USER
+      first: $first
+      last: $last
+      before: $before
+      after: $after
+    ) {
       userCount
       nodes {
         ... on Organization {

--- a/src/shared/apollo.js
+++ b/src/shared/apollo.js
@@ -10,9 +10,13 @@ const createApolloClient = () =>
   new ApolloClient({
     ssrMode: typeof window === 'undefined',
     link: new HttpLink({
-      uri: 'https://rickandmortyapi.com/graphql', // 'https://api.github.com/graphql',
+      uri: 'https://api.github.com/graphql',
       credentials: 'same-origin',
       fetch,
+      headers: {
+        // TODO: this is obviously really really bad but figuring out secrets isn't a priority rn
+        Authorization: 'bearer 5382e90860d4c67f4d7bdd1cbb23cd38950446cb',
+      },
     }),
     cache: new InMemoryCache(),
   });

--- a/src/shared/apollo.js
+++ b/src/shared/apollo.js
@@ -6,20 +6,21 @@ import fetch from 'isomorphic-unfetch';
 
 let cachedClient;
 
-const createApolloClient = () =>
-  new ApolloClient({
+const createApolloClient = () => {
+  const { NEXT_PUBLIC_GITHUB_ACCESS_TOKEN } = process.env;
+  return new ApolloClient({
     ssrMode: typeof window === 'undefined',
     link: new HttpLink({
       uri: 'https://api.github.com/graphql',
       credentials: 'same-origin',
       fetch,
       headers: {
-        // TODO: this is obviously really really bad but figuring out secrets isn't a priority rn
-        Authorization: 'bearer 5382e90860d4c67f4d7bdd1cbb23cd38950446cb',
+        Authorization: `bearer ${NEXT_PUBLIC_GITHUB_ACCESS_TOKEN}`,
       },
     }),
     cache: new InMemoryCache(),
   });
+};
 
 const initializeApollo = (initialState = null) => {
   const client = cachedClient ?? createApolloClient();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10859,6 +10859,13 @@ polished@^3.4.4:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+polished@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.0.5.tgz#3f91873c8f72dec1723b3f892f57fbb22645b23d"
+  integrity sha512-BY2+LVtOHQWBQpGN4GPAKpCdsBePOdSdHTpZegRDRCrvGPkRPTx1DEC+vGjIDPhXS7W2qiBxschnwRWTFdMZag==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,7 +1842,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-controls@6.1.11":
+"@storybook/addon-controls@6.1.11", "@storybook/addon-controls@^6.1.11":
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.1.11.tgz#9a104ac58eefa3cf2b0fb6f4c762b8a39ed239cc"
   integrity sha512-KGK1qk95E+j0yDBgA93ctMCf/z9VosPtldhP2oZDPD8kAKz6dVPXkz7LKgrZYDH4ZySk4fDOApBC8OLe3bxE1g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,7 +1103,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@7.12.5", "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1201,7 +1201,7 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.8.0":
+"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -1572,6 +1572,77 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@material-ui/core@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.2.tgz#f8276dfa40d88304e6ceb98962af73803d27d42d"
+  integrity sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.2"
+    "@material-ui/system" "^4.11.2"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
+"@material-ui/styles@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.2.tgz#e70558be3f41719e8c0d63c7a3c9ae163fdc84cb"
+  integrity sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.0.3"
+    jss-plugin-camel-case "^10.0.3"
+    jss-plugin-default-unit "^10.0.3"
+    jss-plugin-global "^10.0.3"
+    jss-plugin-nested "^10.0.3"
+    jss-plugin-props-sort "^10.0.3"
+    jss-plugin-rule-value-function "^10.0.3"
+    jss-plugin-vendor-prefixer "^10.0.3"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.2.tgz#7f0a754bba3673ed5fdbfa02fe438096c104b1f6"
+  integrity sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@mdx-js/loader@^1.6.19":
   version "1.6.22"
@@ -2573,6 +2644,13 @@
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
   integrity sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
+  integrity sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
   dependencies:
     "@types/react" "*"
 
@@ -4830,6 +4908,11 @@ clone-deep@^0.2.4:
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5337,6 +5420,14 @@ css-to-react-native@^3.0.0:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -5420,7 +5511,7 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.5.7:
+csstype@^2.5.2, csstype@^2.5.7:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.14.tgz#004822a4050345b55ad4dcc00be1d9cf2f4296de"
   integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
@@ -5733,6 +5824,14 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
@@ -7834,6 +7933,11 @@ husky@^4.3.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -7925,6 +8029,13 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite-observable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-2.0.1.tgz#574af29bfbc17eb5947793797bddc94c9d859400"
+  integrity sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==
+  dependencies:
+    symbol-observable "1.2.0"
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -8279,6 +8390,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-map@^2.0.1:
   version "2.0.1"
@@ -9157,6 +9273,77 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.0.tgz#4b0a9c85e65e5eb72cbfba59373686c604d88f72"
+  integrity sha512-GSjPL0adGAkuoqeYiXTgO7PlIrmjv5v8lA6TTBdfxbNYpxADOdGKJgIEkffhlyuIZHlPuuiFYTwUreLUmSn7rg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.5.0"
+
+jss-plugin-default-unit@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.0.tgz#e9f2e89741b0118ba15d52b4c13bda2b27262373"
+  integrity sha512-rsbTtZGCMrbcb9beiDd+TwL991NGmsAgVYH0hATrYJtue9e+LH/Gn4yFD1ENwE+3JzF3A+rPnM2JuD9L/SIIWw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.0"
+
+jss-plugin-global@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.5.0.tgz#eb357ccd35cb4894277fb2117a78d1e498668ad6"
+  integrity sha512-FZd9+JE/3D7HMefEG54fEC0XiQ9rhGtDHAT/ols24y8sKQ1D5KIw6OyXEmIdKFmACgxZV2ARQ5pAUypxkk2IFQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.0"
+
+jss-plugin-nested@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.5.0.tgz#790c506432a23a63c71ceb5044e2ac85f0958702"
+  integrity sha512-ejPlCLNlEGgx8jmMiDk/zarsCZk+DV0YqXfddpgzbO9Toamo0HweCFuwJ3ZO40UFOfqKwfpKMVH/3HUXgxkTMg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.0.tgz#5bcc3bd8e68cd3e2dafb47d67db28fd5a4fcf102"
+  integrity sha512-kTLRvrOetFKz5vM88FAhLNeJIxfjhCepnvq65G7xsAQ/Wgy7HwO1BS/2wE5mx8iLaAWC6Rj5h16mhMk9sKdZxg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.0"
+
+jss-plugin-rule-value-function@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.0.tgz#60ee8240dfe60418e1ba4729adee893cbe9be7a3"
+  integrity sha512-jXINGr8BSsB13JVuK274oEtk0LoooYSJqTBCGeBu2cG/VJ3+4FPs1gwLgsq24xTgKshtZ+WEQMVL34OprLidRA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.5.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.0.tgz#01f04cfff31f43f153f5d71972f5800b10a2eb84"
+  integrity sha512-rux3gmfwDdOKCLDx0IQjTwTm03IfBa+Rm/hs747cOw5Q7O3RaTUIMPKjtVfc31Xr/XI9Abz2XEupk1/oMQ7zRA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.5.0"
+
+jss@10.5.0, jss@^10.0.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.5.0.tgz#0c2de8a29874b2dc8162ab7f34ef6573a87d9dd3"
+  integrity sha512-B6151NvG+thUg3murLNHRPLxTLwQ13ep4SH5brj4d8qKtogOx/jupnpfkPGSHPqvcwKJaCLctpj2lEk+5yGwMw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    indefinite-observable "^2.0.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.1.0"
@@ -10866,6 +11053,11 @@ polished@^4.0.5:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -11505,7 +11697,7 @@ react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
@@ -11571,6 +11763,16 @@ react-textarea-autosize@^8.1.1:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@17.0.1:
   version "17.0.1"
@@ -13066,7 +13268,7 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-symbol-observable@^1.0.2:
+symbol-observable@1.2.0, symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -13298,6 +13500,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinycolor2@^1.4.1:
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11676,6 +11676,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-hook-form@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.13.0.tgz#91e6da52cd3a636724b38ad8bc3704d7bd8a2626"
+  integrity sha512-AADO0EtAGEggII3DNhBCwm7MSwkBWCVo72K32NY6YzhSTBL5bJsBfWJ4/PVGBer31js5ppt+I6/qUyLo8o8AvA==
+
 react-hotkeys@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-2.0.0.tgz#a7719c7340cbba888b0e9184f806a9ec0ac2c53f"


### PR DESCRIPTION
# Overview

Creates a custom user search interface using the Github GraphQL API.

# Screenshots for Mobile and Desktop views (if applicable)

## Before
N/A

## After
![image](https://user-images.githubusercontent.com/1815379/102004330-b2321e00-3cdd-11eb-9705-40c54e8bf7f9.png)


# Details

## General
- [x] user can search against the API and get paginated results
- [x] user can see total count of results back from request
- [x] user can paginate forward and backward 1 page at a time
- [x] useful user information for results is displayed
- [x] clicking on a result takes you to the profile on Github.com


## Automated Testing
No tests currently exist. This PR is un-mergeable until I can get them done. Started running low on time.

### Manual Testing
If you want to make a Github key:
1. Generate a github access token and add to your `.env.local` as `NEXT_PUBLIC_GITHUB_ACCESS_TOKEN`
2. Run `yarn dev`
Go to 3 below

If you don't want to make a Github key:
1. Visit https://next-playground-5qmh6tfyd.vercel.app/
2. In the search bar, enter a username, e.g. `dustin`
Go to 3 below

--- 
3. See results load
4. Click "next" 2 times and see results load
5. Click "previous" 2 times and see previous results load
6. Click on any row and see Github.com open in new window
